### PR TITLE
on deposit error make it so state is not still 'pending'

### DIFF
--- a/src/dapps/Salad/containers/SaladMixContent/SaladMixContent.vue
+++ b/src/dapps/Salad/containers/SaladMixContent/SaladMixContent.vue
@@ -130,7 +130,7 @@ export default {
           
           Toast.responseHandler(`Deposit accepted by the Relayer`, Toast.INFO);
           this.isPending = true;
-          //this.page = 'success'
+          this.page = 'success'
 
       } catch (e) {
           Toast.responseHandler(`Error with your deposit: ${e.message}`, Toast.ERROR);

--- a/src/dapps/Salad/containers/SaladMixContent/SaladMixContent.vue
+++ b/src/dapps/Salad/containers/SaladMixContent/SaladMixContent.vue
@@ -129,13 +129,16 @@ export default {
           await this.salad.submitDepositMetadataAsync(sender, amountInWei, encRecipient, myPubKey, signature);
           
           Toast.responseHandler(`Deposit accepted by the Relayer`, Toast.INFO);
-          this.isSubmitting = false;
           this.isPending = true;
-          this.page = 'success'
+          //this.page = 'success'
 
       } catch (e) {
           Toast.responseHandler(`Error with your deposit: ${e.message}`, Toast.ERROR);
+          this.isPending = false;
           this.err = e
+      }
+      finally {
+          this.isSubmitting = false;
       }
     },
     async initSalad() {


### PR DESCRIPTION
@levackt I'm getting my feet wet here with the git workflow, branches, etc. 
I noticed that when there was an error, the UI was still showing the deposit as "Pending..." so I made the changes referenced here.

Oops I left the success page setting commented out--will fix that. I was playing with the UI.